### PR TITLE
feat: enable dynamic credentials between AWS and Terraform Cloud

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -81,6 +81,25 @@ provider "registry.terraform.io/hashicorp/random" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/tfe" {
+  version = "0.43.0"
+  hashes = [
+    "h1:swg8nynWp8RylMPVW0lCsLbaEYUrcMvN2SYuXgwTqrE=",
+    "zh:091aab22fc9a9ca28951fe5aab5e1522e62d63963f1a32b5dc5cf65ef2bc5aae",
+    "zh:45ed67613daa7472e71f070165b0bb48c90bf1087e3672dfebae89322d3404eb",
+    "zh:5fc55c86be50fa5a1762026c253e3f4ff531a27116b661d2e1e4d37f6a918d6b",
+    "zh:6631e5643af589337702cabf982bd3acdf524865ad3d67cc2f3c0098e825727c",
+    "zh:6b635f9ebb276830410dd4f4ed9b3a91059ba6d7703eab71c26ae14a7b4a9e3c",
+    "zh:829537f6edea999972d91c9f1b135b03faabdcd5d945c0d98be92503f6aa1b93",
+    "zh:ace0593ba69b776fc562c5d8ceac64676556ac2c8b3badd632efca0754a6acd3",
+    "zh:afcb5c3ba8ee6d4f2944664d59bc7b6d0888851f57c9f311c2b422489f4ca5ac",
+    "zh:b0119d5bfbce1b70505271edf2aac3c5c449e8682a7dd1d220e776d031e59a8b",
+    "zh:d54ea33ef57bdf6cf4020aab7da77472d312d16d1bc310dbccdc39acee98af71",
+    "zh:d95ec293fa70e946b6cd657912b33155f8be3413e6128ed2bfa5a493f788e439",
+    "zh:e48598bc78c6c590ab578736e52726a4daf254ad4472cc447f08c1dc1efb0aa3",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/time" {
   version = "0.9.1"
   hashes = [
@@ -97,5 +116,24 @@ provider "registry.terraform.io/hashicorp/time" {
     "zh:f1f46a4f6c65886d2dd27b66d92632232adc64f92145bf8403fe64d5ffa5caea",
     "zh:f79d6155cda7d559c60d74883a24879a01c4d5f6fd7e8d1e3250f3cd215fb904",
     "zh:fd59fa73074805c3575f08cd627eef7acda14ab6dac2c135a66e7a38d262201c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.4"
+  hashes = [
+    "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/credentials.tf
+++ b/credentials.tf
@@ -1,0 +1,42 @@
+data "tls_certificate" "tfc_certificate" {
+  url = "https://${var.tfc_hostname}"
+}
+
+resource "aws_iam_openid_connect_provider" "tfc_provider" {
+  url             = data.tls_certificate.tfc_certificate.url
+  client_id_list  = [var.tfc_aws_audience]
+  thumbprint_list = [data.tls_certificate.tfc_certificate.certificates[0].sha1_fingerprint]
+}
+
+resource "aws_iam_role" "tfc_role" {
+  name                  = "tfc-role"
+  force_detach_policies = true
+
+  assume_role_policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Effect": "Allow",
+     "Principal": {
+       "Federated": "${aws_iam_openid_connect_provider.tfc_provider.arn}"
+     },
+     "Action": "sts:AssumeRoleWithWebIdentity",
+     "Condition": {
+       "StringEquals": {
+         "${var.tfc_hostname}:aud": "${one(aws_iam_openid_connect_provider.tfc_provider.client_id_list)}"
+       },
+       "StringLike": {
+         "${var.tfc_hostname}:sub": "organization:${var.tfc_organisation_name}:project:${var.tfc_project_name}:workspace:${var.tfc_workspace_name}:run_phase:*"
+       }
+     }
+   }
+ ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "tfc_role_superpowers" {
+  role       = aws_iam_role.tfc_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/factory.tf
+++ b/factory.tf
@@ -4,8 +4,8 @@ module "factory" {
   aft_framework_repo_url     = "https://github.com/grendel-consulting/terraform-aws-control_tower_account_factory.git"
   aft_framework_repo_git_ref = "main"
   terraform_distribution     = "tfc"
-  terraform_org_name         = "grendel-consulting"
-  terraform_token            = var.terraform_token
+  terraform_org_name         = var.tfc_organisation_name
+  terraform_token            = var.tfc_token
   terraform_version          = "1.4.4"
 
   ct_management_account_id    = var.ct_management_account_id

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,7 @@ variable "github_owner" {
 variable "ct_home_region" {
   type        = string
   description = "AWS Region where AWS Control Tower is deployed"
+  default     = "eu-west-1"
 }
 
 variable "tf_backend_secondary_region" {
@@ -37,8 +38,38 @@ variable "tf_backend_secondary_region" {
   description = "AWS Region where Terraform backend will be backed up"
 }
 
-variable "terraform_token" {
+variable "tfc_hostname" {
   type        = string
-  description = "Terraform Cloud Token"
+  description = "Hostname of the TFC (or TFE) instance to use with AWS"
+  default     = "app.terraform.io"
+}
+
+variable "tfc_organisation_name" {
+  type        = string
+  description = "Name of your Terraform Cloud organisation"
+  default     = "grendel-consulting"
+}
+
+variable "tfc_project_name" {
+  type        = string
+  description = "Project under which the workspace exists"
+  default     = "Default Project"
+}
+
+variable "tfc_workspace_name" {
+  type        = string
+  description = "Name of the Workspace that will connect to AWS"
+  default     = "cloud-factory"
+}
+
+variable "tfc_aws_audience" {
+  type        = string
+  description = "Audience value to use in run identity tokens"
+  default     = "aws.workload.identity"
+}
+
+variable "tfc_token" {
+  type        = string
+  description = "Authentication token for TFC (or TFE)"
   sensitive   = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,12 @@
+provider "aws" {
+  region = var.ct_home_region
+}
+
+provider "tfe" {
+  hostname = var.tfc_hostname
+  token    = var.tfc_token
+}
+
 terraform {
   cloud {
     organization = "grendel-consulting"

--- a/workspace.tf
+++ b/workspace.tf
@@ -1,0 +1,24 @@
+data "tfe_workspace" "target" {
+  name         = var.tfc_workspace_name
+  organization = var.tfc_organisation_name
+}
+
+resource "tfe_variable" "enable_aws_provider_auth" {
+  workspace_id = data.tfe_workspace.target.id
+
+  key      = "TFC_AWS_PROVIDER_AUTH"
+  value    = "true"
+  category = "env"
+
+  description = "Enable the Workload Identity integration for AWS."
+}
+
+resource "tfe_variable" "tfc_aws_role_arn" {
+  workspace_id = data.tfe_workspace.target.id
+
+  key      = "TFC_AWS_RUN_ROLE_ARN"
+  value    = aws_iam_role.tfc_role.arn
+  category = "env"
+
+  description = "Specific the AWS Role ARN that runs will use to authenticate."
+}


### PR DESCRIPTION
Enable use of [Dynamic Credentials for AWS](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration) using OIDC from Terraform Cloud