### PR TITLE
fix: harden runner hardener

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
-          disable-sudo-and-containers: true
+          disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             api.deps.dev:443


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to only disable sudo privileges during runner hardening, instead of disabling both sudo and container capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->