### PR TITLE
chore: reduce backup retention to minimize AWS Config costs

### DIFF
--- a/factory.tf
+++ b/factory.tf
@@ -22,6 +22,8 @@ module "factory" {
   global_customizations_repo_name               = "${var.github_owner}/cloud-factory-baseline"
   account_customizations_repo_name              = "${var.github_owner}/cloud-factory-customisations"
 
+  backup_recovery_point_retention = 90
+
   aft_feature_delete_default_vpcs_enabled = true
   aft_enable_vpc                          = false
   aft_vpc_endpoints                       = false


### PR DESCRIPTION
Backup recovery points not stored indefinitely, so this **reduces** the restore window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Backup recovery points are now retained for 90 days, extending the restore window and improving data resilience. Users can recover data from a longer timeframe without additional steps. This applies across environments and enhances continuity and compliance needs by keeping recovery points available for three months.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->